### PR TITLE
Introducing LocalizationManager + simple Text Editor for Localization Files

### DIFF
--- a/Assets/Scripts/Input.cs.meta
+++ b/Assets/Scripts/Input.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 9c750b8ad87f10748bd6e6d96f74f5cf
+timeCreated: 1514582797
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Localization.meta
+++ b/Assets/Scripts/Localization.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 48cd3fb129b136a40bce2d96b71b9ab0
+folderAsset: yes
+timeCreated: 1514583468
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Localization/Editor.meta
+++ b/Assets/Scripts/Localization/Editor.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bfae9dadb90a23a45858e97793b315d3
+folderAsset: yes
+timeCreated: 1514586445
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Localization/Editor/LocalizedTextEditor.cs
+++ b/Assets/Scripts/Localization/Editor/LocalizedTextEditor.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+public class LocalizedTextEditor : EditorWindow
+{
+    public LocalizationData localizationData;
+
+    [MenuItem ("Window/Localized Text Editor")]
+    static void Init()
+    {
+        GetWindow(typeof(LocalizedTextEditor)).Show();
+    }
+
+    private void OnGUI()
+    {
+        if (localizationData != null)
+        {
+            SerializedObject serializedObject = new SerializedObject(this);
+            SerializedProperty serializedProperty = serializedObject.FindProperty("localizationData");
+            EditorGUILayout.PropertyField(serializedProperty, true);
+
+            serializedObject.ApplyModifiedProperties();
+
+            if (GUILayout.Button("Save data"))
+            {
+                SaveGameData();
+            }
+        }
+
+        if (GUILayout.Button("Load data"))
+        {
+            LoadGameData();
+        }
+
+        if (GUILayout.Button("Create new data"))
+        {
+            CreateNewData();
+        }
+    }
+
+    private void SaveGameData()
+    {
+        string filePath = EditorUtility.SaveFilePanel("Save localization data file", Path.Combine(Application.streamingAssetsPath,"Localization"), "", "json");
+
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            string dataAsJson = JsonUtility.ToJson(localizationData);
+            File.WriteAllText(filePath, dataAsJson);
+
+
+        }
+    }
+
+    private void LoadGameData()
+    {
+        string filePath = EditorUtility.OpenFilePanel("Select localization data file", Path.Combine(Application.streamingAssetsPath, "Localization"), "json");
+
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            string dataAsJson = File.ReadAllText(filePath);
+            localizationData = JsonUtility.FromJson<LocalizationData>(dataAsJson);
+        }
+    }
+
+    private void CreateNewData()
+    {
+        localizationData = new LocalizationData();
+    }
+}

--- a/Assets/Scripts/Localization/Editor/LocalizedTextEditor.cs.meta
+++ b/Assets/Scripts/Localization/Editor/LocalizedTextEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 742afeb0636bc064996997f6751b89a1
+timeCreated: 1514586454
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Localization/LocalizationData.cs
+++ b/Assets/Scripts/Localization/LocalizationData.cs
@@ -1,0 +1,12 @@
+﻿[System.Serializable]
+public class LocalizationData
+{
+    public LocalizationItem[] data;
+}
+
+[System.Serializable]
+public class LocalizationItem
+{
+    public string key;
+    public string value;
+}

--- a/Assets/Scripts/Localization/LocalizationData.cs.meta
+++ b/Assets/Scripts/Localization/LocalizationData.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: deeb9cba68008294889c268221b3dff8
+timeCreated: 1514584060
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Localization/LocalizationManager.cs
+++ b/Assets/Scripts/Localization/LocalizationManager.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+
+public class LocalizationManager : MonoBehaviour {
+
+    public static LocalizationManager instance;
+
+    private Dictionary<string, string> localizedText;
+    private string missingText = "Localized Text not found";
+
+    public bool IsReady { get; private set; }
+
+	void Awake ()
+    {
+        //Make sure there is only one instance even in different szenes
+	    if (instance == null)
+        {
+            instance = this;
+        }
+        else if (instance != this)
+        {
+            Destroy(gameObject);
+        }
+
+        DontDestroyOnLoad(gameObject);
+
+        IsReady = false;
+    }
+
+    public void LoadLocalizedText(string fileName)
+    {
+        localizedText = new Dictionary<string, string>();
+        string filePath = Path.Combine(Application.streamingAssetsPath, "Localization/" + fileName);
+
+        if(File.Exists(filePath))
+        {
+            string dataAsJson = File.ReadAllText(filePath);
+            LocalizationData loadedData = JsonUtility.FromJson<LocalizationData>(dataAsJson);
+
+            for (int i = 0; i < loadedData.data.Length; i++)
+            {
+                localizedText.Add(loadedData.data[i].key, loadedData.data[i].value);
+            }
+
+            Debug.Log("Localization Manager - Data loaded from File: " + filePath);
+            Debug.Log("Localization Manager - Dictionary contains: " + localizedText.Count + "entries");
+        }
+        else
+        {
+            Debug.LogError("Localization Manager - Cannot find file: " + filePath);
+        }
+
+        IsReady = true;
+    }
+
+    public string GetLocalizedValue(string key)
+    {
+        return localizedText.ContainsKey(key) ? localizedText[key] : missingText;
+    }
+}

--- a/Assets/Scripts/Localization/LocalizationManager.cs.meta
+++ b/Assets/Scripts/Localization/LocalizationManager.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 78a299de2c689304bbaac2bf5d332e97
+timeCreated: 1514583477
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Localization.meta
+++ b/Assets/StreamingAssets/Localization.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d68470f0bb5fc3f4d85d80d1c15e839c
+folderAsset: yes
+timeCreated: 1514587749
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Localization/README.MD
+++ b/Assets/StreamingAssets/Localization/README.MD
@@ -1,0 +1,11 @@
+#####Contains Language Files in JSON-Format
+
+No default structure for keys yet!
+
+```
+example.json
+{"data":[
+	{ "key":"morning", "value":"Good Morning!" },
+	{ "key":"evening","value":"Good evening!" }
+]}
+```

--- a/Assets/StreamingAssets/Localization/README.MD.meta
+++ b/Assets/StreamingAssets/Localization/README.MD.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 59722e8807445bb4ca30f20b6596ec66
+timeCreated: 1514596758
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Localization/test_de.json
+++ b/Assets/StreamingAssets/Localization/test_de.json
@@ -1,0 +1,4 @@
+{"data":[
+	{ "key":"test",	"value":"Guten Morgen" },
+	{ "key":"test2","value":"Guten Abend" }
+]}

--- a/Assets/StreamingAssets/Localization/test_de.json.meta
+++ b/Assets/StreamingAssets/Localization/test_de.json.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5412f82b32fbb1442ae759519bdb5687
+timeCreated: 1514587749
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Localization/test_en.json
+++ b/Assets/StreamingAssets/Localization/test_en.json
@@ -1,0 +1,4 @@
+{"items":[
+	{ "key":"test",	"value":"Good morning" },
+	{ "key":"test2", "value":"Good evening" }
+]}

--- a/Assets/StreamingAssets/Localization/test_en.json.meta
+++ b/Assets/StreamingAssets/Localization/test_en.json.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8a5840f92016dbe47b728388cf25f298
+timeCreated: 1514587797
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -36,6 +36,7 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
**Summary**
This PR fixes/implements the following **Localization: Manager**

* [ ] Bug 1
* [X] Feature 2
* [ ] Breaking changes

**LocalizationData Class:**
-holding the data to make it serializeable
**LocalizationManager Class:**
-providing bool IsReady for showing first load on startup
-initializes with Awake() and holding the first instance of himself
-is persistent through scenes
-can load and store LocalizedTextData from JSON Files
-returns value to a provided key

**LocalizedTextEditor Class:**
-providing a simple integrated text editor for the JSON data
-Load / Save / New

>Is not providing a default structure for keys
>Specification is JSON

**References**
Fixes #105 
